### PR TITLE
feat: remove postprocessing

### DIFF
--- a/apps/web/src/components/home/HomeHero.tsx
+++ b/apps/web/src/components/home/HomeHero.tsx
@@ -1,7 +1,5 @@
 import { Canvas } from '@react-three/fiber'
-import { Bloom, EffectComposer, Vignette } from '@react-three/postprocessing'
 
-import { BlendFunction } from 'postprocessing'
 import { FC, forwardRef, useRef } from 'react'
 
 import { AnimatedBlobs } from './AnimatedBlobs/AnimatedBlobs'
@@ -49,15 +47,6 @@ function ScreenshotsCanvas({
 }) {
   return (
     <Canvas shadows camera={{ fov: 35, position: [0, -1, 11] }} flat linear>
-      <EffectComposer>
-        <Vignette
-          offset={0.1} // vignette offset
-          darkness={0.7} // vignette darkness
-          eskil={false} // Eskil's vignette technique
-          blendFunction={BlendFunction.DARKEN} // blend mode
-        />
-        <Bloom luminanceThreshold={0.7} luminanceSmoothing={0.9} />
-      </EffectComposer>
       <ambientLight intensity={1} />
       <Screenshots sidebarRef={sidebarRef} indicatorRef={indicatorRef} />
     </Canvas>


### PR DESCRIPTION
- fixes #21

吃性能的主要原因是 `EffectComposer` 默认启用了 8x 的多重采样，禁用之后 GPU 使用率降了一半（以上？）

另外，`Vignette` 特效的效果基本看不出来，`Bloom` 更是会起到反作用（文字变模糊），干脆把这两个去掉了，使用率可以再降一半

作为参考，我的显卡是 UHD 730，使用率从 100% 降到了 26%

![change](https://user-images.githubusercontent.com/46285865/218681282-0ea131a0-a47b-4f10-b47e-d7a48bd7bb57.png)
