### PR TITLE
doc: 添加MacBook M1模拟器支持情况

### DIFF
--- a/apps/doc/1.4-Mac模拟器支持.md
+++ b/apps/doc/1.4-Mac模拟器支持.md
@@ -1,0 +1,25 @@
+# Mac模拟器支持
+
+## Apple Silicon芯片
+
+### ✅ [AVD](https://developer.android.com/studio/run/managing-avds)
+
+支持。
+
+## Intel芯片
+
+### ✅ [蓝叠模拟器](https://www.bluestacks.cn/)
+
+完美支持。需要在模拟器 `设置` - `引擎设置` 中打开 `允许ADB连接`
+
+### ✅ [蓝叠模拟器国际版](https://www.bluestacks.com/tw/index.html)
+
+完美支持。需要在模拟器 `设定` - `进阶` 中打开 `Android调试桥`
+
+### ✅ [夜神模拟器](https://www.yeshen.com/)
+
+完美支持。
+
+### ✅ [AVD](https://developer.android.com/studio/run/managing-avds)
+
+支持。


### PR DESCRIPTION
MAA存在Mac版本，而目前部分模拟器尚不支持Mac的M1及最新芯片部署