### PR TITLE
fix: 修复UA检测大小写

### DIFF
--- a/apps/web/src/components/home/HomeActionsRelease/ReleaseModels.tsx
+++ b/apps/web/src/components/home/HomeActionsRelease/ReleaseModels.tsx
@@ -128,18 +128,18 @@ export const detectPlatform = async (): Promise<
 
   const lowerCaseUA = userAgent.toLowerCase()
 
-  if (lowerCaseUA.includes('Windows')) {
-    if (lowerCaseUA.includes('ARM')) {
+  if (lowerCaseUA.includes('windows')) {
+    if (lowerCaseUA.includes('arm')) {
       return 'windows-arm64'
     }
     return 'windows-x64'
   }
 
-  if (lowerCaseUA.includes('Macintosh')) {
+  if (lowerCaseUA.includes('macintosh')) {
     return 'macos-universal'
   }
 
-  if (lowerCaseUA.includes('Linux')) {
+  if (lowerCaseUA.includes('linux')) {
     if (lowerCaseUA.includes('aarch64') || lowerCaseUA.includes('arm64')) {
       return 'linux-aarch64'
     }


### PR DESCRIPTION
67638a3ae3cddf6c7e9f9e17b4013cd307a83053 引入了 `lowerCaseUA`，然而匹配字符串都忘记改成小写了，造成识别不出来平台。