### PR TITLE
docs: 添加安卓模拟器adb端口说明

### DIFF
--- a/apps/doc/1.3-模拟器支持.md
+++ b/apps/doc/1.3-模拟器支持.md
@@ -242,3 +242,54 @@ adb shell input keyevent 26
 5. 任务结束后还原设备分辨率。
 
 _注：如连接失败并提示“发生未知错误”，有可能是触控模式 `Minitouch` 的问题，可切换到 `MaaTouch` 再次尝试。由于 `Adb Input` 操作过于缓慢，请仅将其作为万不得已的模式。_
+
+## 常见安卓模拟器adb端口
+
+参考网易游戏高级游戏开发工程师@赵青青的[博客](https://www.cnblogs.com/zhaoqingqing/p/15238464.html)，常见安卓模拟器的adb端口如下：
+
+|模拟器|端口|
+|-|-|
+|网易MuMu模拟器|7555|
+|夜神安卓模拟器|62001|
+|逍遥安卓模拟器|21503|
+|蓝叠安卓模拟器|5555|
+|雷电安卓模拟器|5555|
+|天天安卓模拟器|5037|
+|安卓模拟器大师|54001|
+|腾讯手游助手|5555|
+
+在Windows与Mac的 `设置` - `连接设置` - `连接地址` 配置中如果有情况需要修改则可以参照上表。
+
+### 特殊情况
+
+当不确定明日方舟所在模拟器的运行端口，或出现MAA开始行动后无法连接错误时，请先打开模拟器，从各个模拟器官网找到其adb所在目录，在该目录下打开命令行或终端输入：
+
+```sh
+#----! use emulator adb binary file to replace adb !----
+# mac/linux
+adb devices
+# windows cmd/PowerShell
+.\adb devices
+```
+
+结果将显示所有多开模拟器的adb端口，根据明日方舟所在模拟器的打开顺序确定对应端口（~~如果这个也忘了可以采用枚举法~~）。
+
+以夜神模拟器为例，参考[官方文档](https://www.yeshen.com/faqs/H15tDZ6YW)，若多开了3个模拟器，在未知端口的情况下，因为windows下夜神模拟器adb路径为`C:\Program Files (x86)\Nox\bin\nox_adb.exe`，因此按`win + R`，输入`cmd`打开终端后先运行命令：
+
+```sh
+# cmd默认路径为C:\Users\[UserName], 为防止其他打开路径, 请输入
+c:
+cd "C:\Program Files (x86)\Nox\bin"
+nox_adb devices
+```
+
+最后一条命令将会输出：
+
+```sh
+List of devices attached
+       127.0.0.1:62001 device
+       127.0.0.1:62025 device
+       127.0.0.1:62026 device
+```
+
+夜神模拟器第一个设备端口`62001`，从第二个开始端口从`62025`开始递增。

--- a/apps/doc/1.4-Mac模拟器支持.md
+++ b/apps/doc/1.4-Mac模拟器支持.md
@@ -30,15 +30,17 @@
 
 ### ✅ [蓝叠模拟器](https://www.bluestacks.cn/)
 
-完美支持。需要在模拟器 `设置` - `引擎设置` 中打开 `允许ADB连接`
+完美支持。需要在模拟器 `设置` - `引擎设置` 中打开 `允许ADB连接`。
 
 ### ✅ [蓝叠模拟器国际版](https://www.bluestacks.com/tw/index.html)
 
-完美支持。需要在模拟器 `设定` - `进阶` 中打开 `Android调试桥`
+完美支持。需要在模拟器 `设定` - `进阶` 中打开 `Android调试桥`。
 
 ### ✅ [夜神模拟器](https://www.yeshen.com/)
 
-完美支持。
+完美支持。需要在MAA `设置` - `连接设置`中使用`adb`连接`127.0.0.1:62001`，注意端口不是默认的`5555`，关于模拟器端口的详细说明参见[1.3-模拟器支持](1.3-模拟器支持.md##常见安卓模拟器adb端口)
+
+补充：mac下夜神模拟器的adb二进制文件的位置为`/Applications/NoxAppPlayer.app/Contents/MacOS/adb`，在父目录`MacOS`下可使用`adb devices`命令查看adb端口
 
 ### ✅ [AVD](https://developer.android.com/studio/run/managing-avds)
 


### PR DESCRIPTION
为常见安卓模拟器加入了端口说明，为夜神模拟器单独加了详细注解。

若后期mac能够支持自动探查模拟器可以取消本说明。