### PR TITLE
feat: check connectivity & use mirrors

### DIFF
--- a/apps/web/src/hooks/use-release.ts
+++ b/apps/web/src/hooks/use-release.ts
@@ -2,16 +2,20 @@ import type { Endpoints } from '@octokit/types'
 
 import useSWR from 'swr'
 
-export type Release =
-  Endpoints['GET /repos/{owner}/{repo}/releases/latest']['response']['data']
+export type ReleaseAsset =
+  Endpoints['GET /repos/{owner}/{repo}/releases/latest']['response']['data']['assets'][number] & {
+    mirrors: string[]
+  }
 
-export type ReleaseAsset = Release['assets'][number]
+export type Release = Omit<
+  Endpoints['GET /repos/{owner}/{repo}/releases/latest']['response']['data'],
+  'assets'
+> & { assets: ReleaseAsset[] }
 
 export const useRelease = () => {
   const { data, ...rest } = useSWR<{
     details: Release
   }>('https://ota.maa.plus/MaaAssistantArknights/api/version/stable.json')
-
   return {
     data: data?.details,
     ...rest,

--- a/apps/web/src/utils/fetch.ts
+++ b/apps/web/src/utils/fetch.ts
@@ -82,11 +82,10 @@ export async function download(
   })
 }
 
-const internalCheckUrlConnectivity = async (
+export async function checkUrlConnectivity(
   url: string,
-  timeout: number,
-  mode: RequestMode,
-) => {
+  timeout = 5000,
+): Promise<boolean> {
   try {
     const controller = new AbortController()
     const signal = controller.signal
@@ -94,7 +93,6 @@ const internalCheckUrlConnectivity = async (
     const response = await fetch(url, {
       method: 'HEAD',
       signal,
-      mode,
     })
     if (!response.ok) {
       return false
@@ -103,17 +101,4 @@ const internalCheckUrlConnectivity = async (
   } catch {
     return false
   }
-}
-
-export async function checkUrlConnectivity(
-  url: string,
-  timeout = 5000,
-): Promise<boolean> {
-  if (await internalCheckUrlConnectivity(url, timeout, 'cors')) {
-    return true
-  }
-  if (await internalCheckUrlConnectivity(url, timeout, 'no-cors')) {
-    return true
-  }
-  return false
 }

--- a/apps/web/src/utils/fetch.ts
+++ b/apps/web/src/utils/fetch.ts
@@ -81,3 +81,39 @@ export async function download(
     xhr.send()
   })
 }
+
+const internalCheckUrlConnectivity = async (
+  url: string,
+  timeout: number,
+  mode: RequestMode,
+) => {
+  try {
+    const controller = new AbortController()
+    const signal = controller.signal
+    setTimeout(() => controller.abort(), Math.max(timeout, 5000))
+    const response = await fetch(url, {
+      method: 'HEAD',
+      signal,
+      mode,
+    })
+    if (!response.ok) {
+      return false
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function checkUrlConnectivity(
+  url: string,
+  timeout = 5000,
+): Promise<boolean> {
+  if (await internalCheckUrlConnectivity(url, timeout, 'cors')) {
+    return true
+  }
+  if (await internalCheckUrlConnectivity(url, timeout, 'no-cors')) {
+    return true
+  }
+  return false
+}

--- a/apps/web/src/utils/sleep.ts
+++ b/apps/web/src/utils/sleep.ts
@@ -1,0 +1,3 @@
+const sleep = (timeout: number) =>
+  new Promise((res) => setTimeout(res, timeout))
+export default sleep


### PR DESCRIPTION
PR 提交了两项更改：
1. 使用 ota api 提供的 mirrors 列表；
2. 在发起下载请求前先检测 mirror 地址是否连通，这样有助于缩短找到可用镜像的时间。

大佬们看一下有啥问题不