### PR TITLE
fix: 修复彩虹按钮为居中旋转

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -53,10 +53,10 @@ html:not(.dark) {
 
 @keyframes allin-download-button-gradient {
   from {
-    transform: rotate(0deg);
+    transform: translate(-50%, -50%) scale(1.15) rotate(0deg);
   }
   to {
-    transform: rotate(360deg);
+    transform: translate(-50%, -50%) scale(1.15) rotate(360deg);
   }
 }
 
@@ -113,23 +113,16 @@ html:not(.dark) {
 .allin-download-button::before {
   content: '';
   position: absolute;
-  top: auto;
-  left: auto;
-  bottom: -100%;
-  right: -100%;
-  width: 400%;
+  left: 50%;
+  top: 50%;
+  width: 100%;
   aspect-ratio: 1;
   z-index: 0;
   pointer-events: none;
   background: conic-gradient(
-    red,
-    orange,
-    gold,
-    green,
-    dodgerblue,
-    blueviolet,
-    magenta,
-    red
+    from 0deg in hsl longer hue,
+    hsl(0, 100%, 66%),
+    hsl(360, 100%, 66%)
   );
   animation: allin-download-button-gradient var(--allin-download-duration) linear infinite reverse !important;
 }
@@ -160,6 +153,6 @@ html:not(.dark) {
 @media (prefers-reduced-motion: reduce) {
   .allin-download-button::before {
     animation: none;
-    transform: rotate(180deg);
+    transform: translate(-50%, -50%) scale(1.15) rotate(180deg);
   }
 }


### PR DESCRIPTION
- 将 ::before 从 400% 偏置定位改为居中 + scale(1.15)，旋转中心现在在按钮中心
- conic-gradient 改用 CSS Color 4 `in hsl longer hue`，色相过渡更均匀
- 修复 prefers-reduced-motion 降级规则缺少 translate/scale 导致定位偏移的问题

## Summary by Sourcery

使彩虹下载按钮的旋转渐变居中，并提升其视觉一致性。

Bug 修复：
- 确保彩虹按钮的渐变旋转以按钮中心为基准，而不是发生偏移。
- 修复 `prefers-reduced-motion` 的降级变换，使在非动画状态下也能保持正确的位置。

增强优化：
- 优化彩虹渐变，改用 CSS Color Level 4 的 HSL longer-hue 插值方式，以实现更平滑的颜色过渡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Center the rainbow download button’s rotating gradient and improve its visual consistency.

Bug Fixes:
- Ensure the rainbow button’s gradient rotation is centered on the button instead of being offset.
- Fix prefers-reduced-motion fallback transform so the non-animated state maintains correct positioning.

Enhancements:
- Refine the rainbow gradient to use CSS Color Level 4 HSL longer-hue interpolation for smoother color transitions.

</details>