### PR TITLE
refactor: 移除镜像检测流程

### DIFF
--- a/apps/web/src/components/home/HomeActionsRelease/HomeActionsRelease.tsx
+++ b/apps/web/src/components/home/HomeActionsRelease/HomeActionsRelease.tsx
@@ -2,12 +2,13 @@ import { GlowButton } from '@/components/foundations/GlowButton/GlowButton'
 import { useLayoutState } from '@/contexts/LayoutStateContext'
 import { Release, useRelease } from '@/hooks/use-release'
 import i18n, { getLanguageOption } from '@/i18n'
-import { downloadBlob } from '@/utils/blob'
-import { checkUrlConnectivity, checkUrlSpeed, download } from '@/utils/fetch'
-import { formatBytes } from '@/utils/format'
-import sleep from '@/utils/sleep'
+import {
+  DetectionFailedSymbol,
+  PLATFORMS,
+  ResolvedPlatform,
+  detectPlatform,
+} from '@/utils/detect'
 import mdiAlertCircle from '@iconify/icons-mdi/alert-circle'
-import mdiCheck from '@iconify/icons-mdi/check'
 import mdiDownload from '@iconify/icons-mdi/download'
 import mdiLoading from '@iconify/icons-mdi/loading'
 import type { IconifyIcon } from '@iconify/react'
@@ -34,69 +35,6 @@ import {
 } from 'react-i18next'
 import { useMount } from 'react-use'
 
-import {
-  DetectionFailedSymbol,
-  PLATFORMS,
-  ResolvedPlatform,
-  detectPlatform,
-} from './ReleaseModels'
-
-type GITHUB_MIRROR_TYPE = {
-  name: string
-  transform: (original: URL) => string
-}
-
-const GITHUB_MIRRORS: GITHUB_MIRROR_TYPE[] = [
-  {
-    name: 'origin',
-    transform: (original: URL) => original.toString(),
-  },
-]
-
-const DataLoadRate: FC<{ loaded: number; total: number }> = ({
-  loaded,
-  total,
-}) => {
-  const percentage = useMemo(() => {
-    const percentage = (loaded / total) * 100
-    return percentage > 100 ? 100 : percentage
-  }, [loaded, total])
-
-  return (
-    <div className="flex flex-row items-center justify-center gap-2 font-mono">
-      <div className="flex flex-col items-start justify-center gap-1">
-        <div className="text-sm transition-colors duration-300">
-          {percentage.toFixed(0)}%
-        </div>
-        <div
-          className={clsx(
-            'w-12 h-1 rounded-full',
-            'dark:bg-white/10',
-            'bg-stone-800/10',
-          )}
-        >
-          <div
-            className={clsx(
-              'h-full rounded-full',
-              'dark:bg-white',
-              'bg-stone-800',
-            )}
-            style={{ width: `${percentage}%` }}
-          />
-        </div>
-      </div>
-      <div className="flex flex-col items-end justify-center">
-        <div className="text-sm transition-colors duration-300">
-          {formatBytes(loaded, 1)}
-        </div>
-        <div className="text-sm transition-colors duration-300">
-          {formatBytes(total, 1)}
-        </div>
-      </div>
-    </div>
-  )
-}
-
 interface DownloadStateProps {
   icon: IconifyIcon
   iconClassName?: string
@@ -116,7 +54,7 @@ export const DownloadState: FC<DownloadStateProps> = forwardRef<
     return (
       <motion.div
         className={clsx(
-          'flex py-6 px-3 flex-col items-center justify-center font-normal transition-colors duration-300',
+          'flex py-6 px-5 flex-col items-center justify-center font-normal transition-colors duration-300',
           'dark:text-white',
           'text-stone-800',
           className,
@@ -163,36 +101,7 @@ type DownloadDetectionStates =
       state: 'idle'
     }
   | {
-      state: 'detecting'
-      detected: number
-    }
-  | {
-      state: 'speedTesting'
-      mirrorIndex: number
-    }
-  | {
-      state: 'detected'
-      availableMirror: number
-      canTestSpeed: boolean
-      cantTestSpeedReason: 'saveData' | 'mobile' | 'ok'
-    }
-  | {
-      state: 'connecting'
-      mirrorIndex: number
-      mirrorLatency: number
-      mirrorSpeed: number
-    }
-  | {
       state: 'downloading'
-      mirrorIndex: number
-      progressDownloaded: number
-      progressTotal: number
-    }
-  | {
-      state: 'downloaded'
-    }
-  | {
-      state: 'fallback'
     }
 
 type CompatibilityConfirmReason = 'detectWrong' | 'otherDevice'
@@ -386,7 +295,7 @@ const CompatibilityFinalConfirmModal: FC<{
                 translucent
                 bordered
                 onClick={onClose}
-                className="allin-download-button relative text-white isolate overflow-hidden *:relative *:z-10"
+                className="allin-download-button relative isolate overflow-hidden *:relative *:z-10"
               >
                 <span className="px-2 py-0.5 text-sm font-semibold">
                   {cancelText}
@@ -408,7 +317,15 @@ const AllPlatformsModal: FC<{
   currentPlatformId: string | null | typeof DetectionFailedSymbol
   onClose: () => void
   onConfirm: () => void
-}> = ({ open, title, warning, platforms, currentPlatformId, onClose, onConfirm }) => {
+}> = ({
+  open,
+  title,
+  warning,
+  platforms,
+  currentPlatformId,
+  onClose,
+  onConfirm,
+}) => {
   const { t } = useTranslation()
 
   return (
@@ -446,7 +363,12 @@ const AllPlatformsModal: FC<{
                 onClick={onClose}
                 className="p-1 rounded-lg hover:bg-stone-200/60 dark:hover:bg-zinc-700/60 transition-colors"
               >
-                <Icon icon={mdiAlertCircle} width="18" height="18" className="opacity-50" />
+                <Icon
+                  icon={mdiAlertCircle}
+                  width="18"
+                  height="18"
+                  className="opacity-50"
+                />
               </button>
             </div>
 
@@ -512,156 +434,22 @@ const DownloadButton: FC<{
     () => detectedPlatformLabel || t('release.platformDetect.failure'),
     [detectedPlatformLabel, t],
   )
-  const mirrorsTemplate = useMemo(() => {
-    const baseMirrors = [
-      ...platform.asset.mirrors.map((url) => ({
-        transform: () => url,
-        name: new URL(url).hostname,
-      })),
-      ...GITHUB_MIRRORS,
-    ]
+  const downloadMAA = () => {
+    setLoadState({ state: 'downloading' })
+    window.location.href = href
+  }
 
-    // Windows x64 优先使用国内镜像
-    if (platform.platform.id === 'windows-x64' && releaseName) {
-      return [
-        {
-          name: 'download.maa.plus',
-          transform: () =>
-            `https://download.maa.plus/MAA/MAA-${releaseName}-win-x64.zip`,
-        },
-        ...baseMirrors,
-      ]
-    }
-
-    return baseMirrors
-  }, [platform.asset.mirrors, platform.platform.id, releaseName])
-
-  const detectDownload = useCallback(async () => {
-    setLoadState({ state: 'detecting', detected: 0 })
-    const original = new URL(href)
-    const mirrors: [number, string, DOMHighResTimeStamp, number][] = []
-    await Promise.all(
-      mirrorsTemplate.map(async (mirror, index) => {
-        const mirrorUrl = mirror.transform(original)
-        const result = await checkUrlConnectivity(mirrorUrl)
-        if (typeof result === 'number') {
-          mirrors.push([index, mirrorUrl, result, -1])
-        }
-        setLoadState((prev) => {
-          if (prev.state === 'detecting') {
-            return {
-              ...prev,
-              detected: prev.detected + 1,
-            }
-          }
-          return prev
-        })
-      }),
-    )
-    setLoadState({ state: 'detecting', detected: mirrorsTemplate.length })
-    await sleep(300)
-    mirrors.sort(([, , a], [, , b]) => a - b)
-    try {
-      if (Reflect.has(navigator, 'connection')) {
-        if (navigator.connection?.saveData) {
-          setLoadState({
-            state: 'detected',
-            availableMirror: mirrors.length,
-            canTestSpeed: false,
-            cantTestSpeedReason: 'saveData',
-          })
-        } else if (
-          ['slow-2g', '2g', '3g'].includes(
-            navigator.connection?.effectiveType || '4g',
-          ) ||
-          ['bluetooth', 'cellular', 3, 4].includes(
-            navigator.connection?.type || 'unknown',
-          )
-        ) {
-          setLoadState({
-            state: 'detected',
-            availableMirror: mirrors.length,
-            canTestSpeed: false,
-            cantTestSpeedReason: 'mobile',
-          })
-        } else {
-          throw new Error()
-        }
-      } else {
-        throw new Error()
-      }
-    } catch {
-      for (const [i, [index, mirror]] of mirrors.entries()) {
-        setLoadState({
-          state: 'speedTesting',
-          mirrorIndex: index + 1,
-        })
-        const mirrorSpeed = await checkUrlSpeed(mirror)
-        mirrors[i][3] = mirrorSpeed
-      }
-      setLoadState({
-        state: 'detected',
-        availableMirror: mirrors.length,
-        canTestSpeed: true,
-        cantTestSpeedReason: 'ok',
-      })
-    }
-    mirrors.sort(([, , , a], [, , , b]) => b - a)
-    await sleep(500)
-    for (const [index, mirror, mirrorLatency, mirrorSpeed] of mirrors) {
-      try {
-        setLoadState({
-          state: 'connecting',
-          mirrorIndex: index + 1,
-          mirrorLatency,
-          mirrorSpeed,
-        })
-        await sleep(1000)
-        await download(mirror, {
-          ttfbTimeout: 3500,
-          onProgress: (progressEvent) => {
-            setLoadState({
-              state: 'downloading',
-              mirrorIndex: index + 1,
-              progressDownloaded: progressEvent.loaded,
-              progressTotal: progressEvent.total,
-            })
-          },
-        }).then((blob) => {
-          downloadBlob(blob, href.split('/').pop()!)
-
-          setLoadState({ state: 'downloaded' })
-        })
-
-        break
-      } catch (err) {
-        console.warn(
-          'download mirror detection: unable to detect download to mirror',
-          err,
-        )
-      }
-    }
-    setLoadState((prev) => {
-      if (prev.state !== 'downloaded') {
-        return {
-          state: 'fallback',
-        }
-      }
-      return prev
-    })
-  }, [href, mirrorsTemplate])
-
-  const handleDownloadClick = useCallback(() => {
+  const handleDownloadClick = () => {
     if (requiresCompatibilityConfirm) {
       setFinalConfirmReason(null)
       setCompatibilityModalOpen(true)
       return
     }
 
-    void detectDownload()
-  }, [detectDownload, requiresCompatibilityConfirm])
+    downloadMAA()
+  }
 
-  const handleCompatibilityConfirm = useCallback(() => {
+  const handleCompatibilityConfirm = () => {
     if (!finalConfirmReason) {
       return
     }
@@ -672,25 +460,19 @@ const DownloadButton: FC<{
     })
     setFinalConfirmReason(null)
     setCompatibilityModalOpen(false)
-    void detectDownload()
-  }, [
-    detectDownload,
-    finalConfirmReason,
-    recommendedPlatformLabel,
-    selectedPlatformLabel,
-  ])
+    downloadMAA()
+  }
 
-  const handleSelectCompatibilityReason = useCallback(
-    (reason: CompatibilityConfirmReason) => {
-      setFinalConfirmReason(reason)
-    },
-    [],
-  )
+  const handleSelectCompatibilityReason = (
+    reason: CompatibilityConfirmReason,
+  ) => {
+    setFinalConfirmReason(reason)
+  }
 
-  const handleCloseCompatibilityFlow = useCallback(() => {
+  const handleCloseCompatibilityFlow = () => {
     setFinalConfirmReason(null)
     setCompatibilityModalOpen(false)
-  }, [])
+  }
 
   useEffect(() => {
     if (!compatibilityModalOpen && !finalConfirmReason) {
@@ -709,28 +491,6 @@ const DownloadButton: FC<{
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [compatibilityModalOpen, finalConfirmReason])
-
-  useEffect(() => {
-    if (loadState.state === 'fallback') {
-      console.warn('no mirrors responded correctly; fallback to original URL')
-      window.location.href = href
-    }
-  }, [loadState, href])
-
-  useEffect(() => {
-    if (loadState.state === 'downloading') {
-      window.onbeforeunload = () => {
-        // this is basically useless lol. all you need is a non-null value to the window.onbeforeunload property
-        return 'Please do not close this window until the download is complete.'
-      }
-    } else {
-      window.onbeforeunload = null
-    }
-
-    return () => {
-      window.onbeforeunload = null
-    }
-  }, [loadState])
 
   if (loadState.state === 'idle') {
     return (
@@ -848,102 +608,17 @@ const DownloadButton: FC<{
         />
       </>
     )
-  } else if (loadState.state === 'detecting') {
-    return (
-      <DownloadState
-        iconClassName="animate-spin"
-        icon={mdiLoading}
-        title={t('release.mirrorDetect.detecting', {
-          current: loadState.detected,
-          total: mirrorsTemplate.length,
-        })}
-        isCurrentPlatform={isCurrentPlatform}
-      />
-    )
-  } else if (loadState.state === 'speedTesting') {
-    return (
-      <DownloadState
-        iconClassName="animate-spin"
-        icon={mdiLoading}
-        title={t('release.speedTest.testing', { index: loadState.mirrorIndex })}
-        isCurrentPlatform={isCurrentPlatform}
-      />
-    )
-  } else if (loadState.state === 'detected') {
-    const title = loadState.canTestSpeed
-      ? t('release.speedTest.success', { count: loadState.availableMirror })
-      : t('release.speedTest.failure', {
-          count: loadState.availableMirror,
-          reason: t(
-            `release.speedTest.reasons.${loadState.cantTestSpeedReason}`,
-          ),
-        })
-
-    return (
-      <DownloadState
-        iconClassName="animate-spin"
-        icon={mdiLoading}
-        title={title}
-        isCurrentPlatform={isCurrentPlatform}
-      />
-    )
-  } else if (loadState.state === 'connecting') {
-    const title =
-      loadState.mirrorSpeed > 0
-        ? t('release.download.connectingWithSpeed', {
-            index: loadState.mirrorIndex,
-            latency: loadState.mirrorLatency.toFixed(3),
-            speed: ((loadState.mirrorSpeed / 1024 / 1024) * 1000).toFixed(3),
-          })
-        : t('release.download.connectingWithoutSpeed', {
-            index: loadState.mirrorIndex,
-            latency: loadState.mirrorLatency.toFixed(3),
-          })
-
-    return (
-      <DownloadState
-        iconClassName="animate-spin"
-        icon={mdiLoading}
-        title={title}
-        isCurrentPlatform={isCurrentPlatform}
-      />
-    )
   } else if (loadState.state === 'downloading') {
     return (
       <DownloadState
         iconClassName="animate-spin"
         icon={mdiLoading}
         title={
-          <div className="flex items-center">
-            <span className="mr-4">
-              {t('release.download.downloadingFromMirror', {
-                index: loadState.mirrorIndex,
-              })}
-            </span>
-            <DataLoadRate
-              loaded={loadState.progressDownloaded}
-              total={loadState.progressTotal}
-            />
+          <div className="flex items-center gap-4">
+            <span>{t('release.download.downloadingFromGithub')}</span>
           </div>
         }
         className="tabular-nums"
-        isCurrentPlatform={isCurrentPlatform}
-      />
-    )
-  } else if (loadState.state === 'downloaded') {
-    return (
-      <DownloadState
-        icon={mdiCheck}
-        title={t(platform.platform.messages.downloaded)}
-        isCurrentPlatform={isCurrentPlatform}
-      />
-    )
-  } else if (loadState.state === 'fallback') {
-    return (
-      <DownloadState
-        iconClassName="animate-spin"
-        icon={mdiLoading}
-        title={t('release.download.downloadingFallback')}
         isCurrentPlatform={isCurrentPlatform}
       />
     )
@@ -1143,13 +818,16 @@ export const DownloadButtons: FC<{ release: Release }> = ({ release }) => {
             exit={{ opacity: 0, scale: 0.8 }}
             className={`flex items-center gap-4 ${isWidthOverflow ? 'flex-col w-full' : ''}`}
           >
-            <GlowButton bordered onClick={() => {
-              if (viewAll) {
-                setViewAll(false)
-              } else {
-                setAllPlatformsModalOpen(true)
-              }
-            }}>
+            <GlowButton
+              bordered
+              onClick={() => {
+                if (viewAll) {
+                  setViewAll(false)
+                } else {
+                  setAllPlatformsModalOpen(true)
+                }
+              }}
+            >
               <div className="text-base">
                 {viewAll
                   ? t('release.buttonLabels.collapse')

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -53,10 +53,10 @@ html:not(.dark) {
 
 @keyframes allin-download-button-gradient {
   from {
-    transform: translate(-50%, -50%) scale(1.15) rotate(0deg);
+    transform: translate(-50%, -50%) scale(1.5) rotate(0deg);
   }
   to {
-    transform: translate(-50%, -50%) scale(1.15) rotate(360deg);
+    transform: translate(-50%, -50%) scale(1.5) rotate(360deg);
   }
 }
 

--- a/apps/web/src/locales/en-us.json
+++ b/apps/web/src/locales/en-us.json
@@ -2,38 +2,23 @@
     "platforms": {
         "windows-x64": {
             "title": "Windows",
-            "subtitle": "x64",
-            "messages": {
-                "downloaded": "Download completed. Extract the files and run MAA.exe"
-            }
+            "subtitle": "x64"
         },
         "windows-arm64": {
             "title": "Windows",
-            "subtitle": "arm64",
-            "messages": {
-                "downloaded": "Download completed. Extract the files and run MAA.exe"
-            }
+            "subtitle": "arm64"
         },
         "macos-universal": {
             "title": "macOS",
-            "subtitle": "Universal",
-            "messages": {
-                "downloaded": "Download completed. Open the disk image and drag MAA.app to your Applications folder"
-            }
+            "subtitle": "Universal"
         },
         "linux-x64": {
             "title": "Linux",
-            "subtitle": "x64 Dynamic Library",
-            "messages": {
-                "downloaded": "Dynamic libraries and resource files downloaded. (Linux version has no GUI yet)"
-            }
+            "subtitle": "x64 Dynamic Library"
         },
         "linux-aarch64": {
             "title": "Linux",
-            "subtitle": "aarch64 Dynamic Library",
-            "messages": {
-                "downloaded": "Dynamic libraries and resource files downloaded. (Linux version has no GUI yet)"
-            }
+            "subtitle": "aarch64 Dynamic Library"
         }
     },
     "release": {
@@ -66,23 +51,8 @@
                 }
             }
         },
-        "mirrorDetect": {
-            "detecting": "Checking download mirror availability ({{current}}/{{total}})..."
-        },
-        "speedTest": {
-            "testing": "Testing download speed for mirror #{{index}}...",
-            "success": "Found {{count}} available mirrors (sorted by download speed)",
-            "failure": "Found {{count}} available mirrors (unable to test download speeds due to {{reason}}, sorted by latency)",
-            "reasons": {
-                "saveData": "data-saving mode enabled",
-                "mobile": "mobile network detected"
-            }
-        },
         "download": {
-            "connectingWithSpeed": "Attempting download from mirror #{{index}} (latency: {{latency}} ms, speed test: {{speed}} MiB/s)...",
-            "connectingWithoutSpeed": "Attempting download from mirror #{{index}} (latency: {{latency}} ms)...",
-            "downloadingFromMirror": "Downloading from mirror #{{index}}...",
-            "downloadingFallback": "Downloading from GitHub...",
+            "downloadingFromGithub": "Downloading from GitHub...",
             "invalidState": "Invalid download state. Please refresh the page and try again."
         }
     },

--- a/apps/web/src/locales/ja-jp.json
+++ b/apps/web/src/locales/ja-jp.json
@@ -2,38 +2,23 @@
     "platforms": {
         "windows-x64": {
             "title": "Windows",
-            "subtitle": "x64",
-            "messages": {
-                "downloaded": "ダウンロードが完了しました。解凍後、MAA.exe を実行してください"
-            }
+            "subtitle": "x64"
         },
         "windows-arm64": {
             "title": "Windows",
-            "subtitle": "arm64",
-            "messages": {
-                "downloaded": "ダウンロードが完了しました。解凍後、MAA.exe を実行してください"
-            }
+            "subtitle": "arm64"
         },
         "macos-universal": {
             "title": "macOS",
-            "subtitle": "ユニバーサル",
-            "messages": {
-                "downloaded": "ダウンロードが完了しました。ディスクイメージを開き、MAA.app をアプリケーションフォルダにドラッグしてください"
-            }
+            "subtitle": "ユニバーサル"
         },
         "linux-x64": {
             "title": "Linux",
-            "subtitle": "x64 ダイナミックライブラリ",
-            "messages": {
-                "downloaded": "ダイナミックライブラリとリソースファイルがダウンロード完了しました（Linux 版には GUI はありません）"
-            }
+            "subtitle": "x64 ダイナミックライブラリ"
         },
         "linux-aarch64": {
             "title": "Linux",
-            "subtitle": "aarch64 ダイナミックライブラリ",
-            "messages": {
-                "downloaded": "ダイナミックライブラリとリソースファイルがダウンロード完了しました（Linux 版には GUI はありません）"
-            }
+            "subtitle": "aarch64 ダイナミックライブラリ"
         }
     },
     "release": {
@@ -66,23 +51,8 @@
                 }
             }
         },
-        "mirrorDetect": {
-            "detecting": "ダウンロードミラーの有効性を検出中（{{current}}/{{total}}）..."
-        },
-        "speedTest": {
-            "testing": "ダウンロードミラー #{{index}} の速度を検出中...",
-            "success": "{{count}} 個の有効なミラーが検出されました（ダウンロード速度順に並べ替えています）",
-            "failure": "{{count}} 個の有効なミラーが検出されました（{{reason}}のため、ミラーのダウンロード速度を検出できませんでした。ミラーの遅延順に並べ替えています）",
-            "reasons": {
-                "saveData": "ユーザーが「データ節約」モードを有効にしています",
-                "mobile": "ユーザーがモバイルネットワークを使用しています"
-            }
-        },
         "download": {
-            "connectingWithSpeed": "ミラー #{{index}}（遅延：{{latency}} ms、速度：{{speed}} MiB/s）からダウンロードを試みています...",
-            "connectingWithoutSpeed": "ミラー #{{index}}（遅延：{{latency}} ms）からダウンロードを試みています...",
-            "downloadingFromMirror": "ミラー #{{index}} からダウンロード中...",
-            "downloadingFallback": "GitHub からダウンロード中...",
+            "downloadingFromGithub": "GitHub からダウンロード中...",
             "invalidState": "無効なダウンロード状態です。ページをリフレッシュして再試行してください。"
         }
     },

--- a/apps/web/src/locales/ko-kr.json
+++ b/apps/web/src/locales/ko-kr.json
@@ -2,38 +2,23 @@
     "platforms": {
         "windows-x64": {
             "title": "Windows",
-            "subtitle": "x64",
-            "messages": {
-                "downloaded": "다운로드 완료, 압축 해제 후 MAA.exe를 실행해주세요"
-            }
+            "subtitle": "x64"
         },
         "windows-arm64": {
             "title": "Windows",
-            "subtitle": "arm64",
-            "messages": {
-                "downloaded": "다운로드 완료, 압축 해제 후 MAA.exe를 실행해주세요"
-            }
+            "subtitle": "arm64"
         },
         "macos-universal": {
             "title": "macOS",
-            "subtitle": "범용",
-            "messages": {
-                "downloaded": "다운로드 완료, 디스크 이미지를 열고 MAA.app을 응용 프로그램 폴더로 드래그해주세요"
-            }
+            "subtitle": "범용"
         },
         "linux-x64": {
             "title": "Linux",
-            "subtitle": "x64 동적 라이브러리",
-            "messages": {
-                "downloaded": "동적 라이브러리와 리소스 파일 다운로드 완료 (Linux 버전은 GUI가 없어요)"
-            }
+            "subtitle": "x64 동적 라이브러리"
         },
         "linux-aarch64": {
             "title": "Linux",
-            "subtitle": "aarch64 동적 라이브러리",
-            "messages": {
-                "downloaded": "동적 라이브러리와 리소스 파일 다운로드 완료 (Linux 버전은 GUI가 없어요)"
-            }
+            "subtitle": "aarch64 동적 라이브러리"
         }
     },
     "release": {
@@ -66,23 +51,8 @@
                 }
             }
         },
-        "mirrorDetect": {
-            "detecting": "다운로드 Mirror 가용성 확인 중 ({{current}}/{{total}})..."
-        },
-        "speedTest": {
-            "testing": "다운로드 Mirror #{{index}} 속도 테스트 중...",
-            "success": "{{count}}개의 사용 가능한 Mirror 발견 (다운로드 속도순으로 정렬)",
-            "failure": "{{count}}개의 사용 가능한 Mirror 발견 ({{reason}}으로 인해 다운로드 속도를 테스트할 수 없어 지연 시간순으로 정렬)",
-            "reasons": {
-                "saveData": "사용자가 \"데이터 절약\" 모드를 활성화",
-                "mobile": "사용자가 모바일 네트워크를 사용 중"
-            }
-        },
         "download": {
-            "connectingWithSpeed": "Mirror #{{index}}에서 다운로드 시도 중 (지연시간: {{latency}} ms, 속도: {{speed}} MiB/s)...",
-            "connectingWithoutSpeed": "Mirror #{{index}}에서 다운로드 시도 중 (지연시간: {{latency}} ms)...",
-            "downloadingFromMirror": "Mirror #{{index}}에서 다운로드 중...",
-            "downloadingFallback": "GitHub에서 다운로드 중...",
+            "downloadingFromGithub": "GitHub에서 다운로드 중...",
             "invalidState": "잘못된 다운로드 상태입니다. 페이지를 새로고침하여 다시 시도해주세요."
         }
     },

--- a/apps/web/src/locales/zh-cn.json
+++ b/apps/web/src/locales/zh-cn.json
@@ -2,38 +2,23 @@
     "platforms": {
         "windows-x64": {
             "title": "Windows",
-            "subtitle": "x64",
-            "messages": {
-                "downloaded": "下载完成，解压后运行 MAA.exe 即可"
-            }
+            "subtitle": "x64"
         },
         "windows-arm64": {
             "title": "Windows",
-            "subtitle": "arm64",
-            "messages": {
-                "downloaded": "下载完成，解压后运行 MAA.exe 即可"
-            }
+            "subtitle": "arm64"
         },
         "macos-universal": {
             "title": "macOS",
-            "subtitle": "通用",
-            "messages": {
-                "downloaded": "下载完成，打开磁盘映像后将 MAA.app 拖入应用程序文件夹即可"
-            }
+            "subtitle": "通用"
         },
         "linux-x64": {
             "title": "Linux",
-            "subtitle": "x64 动态库",
-            "messages": {
-                "downloaded": "动态库与资源文件下载完成（Linux 版本暂无 GUI）"
-            }
+            "subtitle": "x64 动态库"
         },
         "linux-aarch64": {
             "title": "Linux",
-            "subtitle": "aarch64 动态库",
-            "messages": {
-                "downloaded": "动态库与资源文件下载完成（Linux 版本暂无 GUI）"
-            }
+            "subtitle": "aarch64 动态库"
         }
     },
     "release": {
@@ -66,23 +51,8 @@
                 }
             }
         },
-        "mirrorDetect": {
-            "detecting": "正在检测下载镜像可用性（{{current}}/{{total}}）..."
-        },
-        "speedTest": {
-            "testing": "正在检测下载镜像 #{{index}} 速度...",
-            "success": "检测到 {{count}} 个可用镜像（已按下载速度排序）",
-            "failure": "检测到 {{count}} 个可用镜像（由于{{reason}}，无法检测镜像下载速度，按镜像延迟排序）",
-            "reasons": {
-                "saveData": "已启用“流量节省”模式",
-                "mobile": "正在使用移动网络"
-            }
-        },
         "download": {
-            "connectingWithSpeed": "正在尝试从镜像 #{{index}}（延迟：{{latency}} ms，测速：{{speed}} MiB/s）下载...",
-            "connectingWithoutSpeed": "正在尝试从镜像 #{{index}}（延迟：{{latency}} ms）下载...",
-            "downloadingFromMirror": "正在从镜像 #{{index}} 下载...",
-            "downloadingFallback": "正在从海外源（Github）下载...",
+            "downloadingFromGithub": "正在通过 GitHub 下载...",
             "invalidState": "无效的下载状态，请刷新页面重试。"
         }
     },

--- a/apps/web/src/locales/zh-tw.json
+++ b/apps/web/src/locales/zh-tw.json
@@ -2,38 +2,23 @@
     "platforms": {
         "windows-x64": {
             "title": "Windows",
-            "subtitle": "x64",
-            "messages": {
-                "downloaded": "下載完成，解壓縮後執行 MAA.exe 即可"
-            }
+            "subtitle": "x64"
         },
         "windows-arm64": {
             "title": "Windows",
-            "subtitle": "arm64",
-            "messages": {
-                "downloaded": "下載完成，解壓縮後執行 MAA.exe 即可"
-            }
+            "subtitle": "arm64"
         },
         "macos-universal": {
             "title": "macOS",
-            "subtitle": "通用版本",
-            "messages": {
-                "downloaded": "下載完成後，打開磁碟映像檔，將 MAA.app 拖曳到應用程式資料夾即可"
-            }
+            "subtitle": "通用版本"
         },
         "linux-x64": {
             "title": "Linux",
-            "subtitle": "x64 動態函式庫",
-            "messages": {
-                "downloaded": "動態函式庫與資源檔案下載完成（Linux 版本暫無 GUI）"
-            }
+            "subtitle": "x64 動態函式庫"
         },
         "linux-aarch64": {
             "title": "Linux",
-            "subtitle": "aarch64 動態函式庫",
-            "messages": {
-                "downloaded": "動態函式庫與資源檔案下載完成（Linux 版本暫無 GUI）"
-            }
+            "subtitle": "aarch64 動態函式庫"
         }
     },
     "release": {
@@ -66,23 +51,8 @@
                 }
             }
         },
-        "mirrorDetect": {
-            "detecting": "正在檢測下載鏡像可用性（{{current}}/{{total}}）..."
-        },
-        "speedTest": {
-            "testing": "正在測試鏡像 #{{index}} 的下載速度...",
-            "success": "已偵測到 {{count}} 個可用鏡像（已依下載速度排序）",
-            "failure": "已偵測到 {{count}} 個可用鏡像（由於{{reason}}，無法測試下載速度，已依鏡像延遲排序）",
-            "reasons": {
-                "saveData": "使用者已開啟節省流量模式",
-                "mobile": "使用者目前使用行動網路"
-            }
-        },
         "download": {
-            "connectingWithSpeed": "正在嘗試從鏡像 #{{index}}（延遲：{{latency}} ms，速度：{{speed}} MiB/s）下載...",
-            "connectingWithoutSpeed": "正在嘗試從鏡像 #{{index}}（延遲：{{latency}} ms）下載...",
-            "downloadingFromMirror": "正在從鏡像 #{{index}} 下載...",
-            "downloadingFallback": "正在從 GitHub 下載...",
+            "downloadingFromGithub": "正在透過 GitHub 下載...",
             "invalidState": "無效的下載狀態，請重新整理頁面後再試一次。"
         }
     },

--- a/apps/web/src/utils/detect.ts
+++ b/apps/web/src/utils/detect.ts
@@ -9,9 +9,6 @@ export interface PlatformPredicate {
   icon: IconifyIcon
   title: string
   subtitle: string
-  messages: {
-    downloaded: string
-  }
   assetMatcher: (release: Release) => ReleaseAsset | undefined
 }
 
@@ -21,9 +18,6 @@ export const PLATFORMS: PlatformPredicate[] = [
     icon: mdiWindows,
     title: 'platforms.windows-x64.title',
     subtitle: 'platforms.windows-x64.subtitle',
-    messages: {
-      downloaded: 'platforms.windows-x64.messages.downloaded',
-    },
     assetMatcher: (release) => {
       return release.assets.find((el) => /^MAA-v.*-win-x64\.zip/.test(el.name))
     },
@@ -33,9 +27,6 @@ export const PLATFORMS: PlatformPredicate[] = [
     icon: mdiWindows,
     title: 'platforms.windows-arm64.title',
     subtitle: 'platforms.windows-arm64.subtitle',
-    messages: {
-      downloaded: 'platforms.windows-arm64.messages.downloaded',
-    },
     assetMatcher: (release) => {
       return release.assets.find((el) =>
         /^MAA-v.*-win-arm64\.zip/.test(el.name),
@@ -47,9 +38,6 @@ export const PLATFORMS: PlatformPredicate[] = [
     icon: mdiApple,
     title: 'platforms.macos-universal.title',
     subtitle: 'platforms.macos-universal.subtitle',
-    messages: {
-      downloaded: 'platforms.macos-universal.messages.downloaded',
-    },
     assetMatcher: (release) => {
       return release.assets.find((el) =>
         /^MAA-v.*-macos-universal\.dmg/.test(el.name),
@@ -61,9 +49,6 @@ export const PLATFORMS: PlatformPredicate[] = [
     icon: mdiLinux,
     title: 'platforms.linux-x64.title',
     subtitle: 'platforms.linux-x64.subtitle',
-    messages: {
-      downloaded: 'platforms.linux-x64.messages.downloaded',
-    },
     assetMatcher: (release) => {
       return release.assets.find((el) =>
         /^MAA-v.*-linux-x86_64\.tar\.gz/.test(el.name),
@@ -75,9 +60,6 @@ export const PLATFORMS: PlatformPredicate[] = [
     icon: mdiLinux,
     title: 'platforms.linux-aarch64.title',
     subtitle: 'platforms.linux-aarch64.subtitle',
-    messages: {
-      downloaded: 'platforms.linux-aarch64.messages.downloaded',
-    },
     assetMatcher: (release) => {
       return release.assets.find((el) =>
         /^MAA-v.*-linux-aarch64\.tar\.gz/.test(el.name),


### PR DESCRIPTION
## Summary

- 移除多镜像连通性检测、测速、回滚逻辑，下载改为直接跳转 GitHub URL
- 将 `ReleaseModels.tsx` 移至 `utils/detect.ts`，清理 `PlatformPredicate.messages` 字段（不再需要下载完成提示）
- 清理各语言 locale 中镜像检测/测速相关翻译项
- CSS 调整：渐变光晕 scale 1.15 → 1.5，按钮 padding 微调

## Summary by Sourcery

简化发布版本的下载流程，移除镜像检测和进度跟踪，直接将用户重定向到 GitHub 下载链接。

增强内容：
- 精简下载状态机，仅处理空闲和下载中两种状态，并更新界面文案以体现直接从 GitHub 下载。
- 将平台检测的定义移动到共享的 `utils/detect` 模块中，并移除按平台划分的“已下载”消息元数据。
- 调整下载按钮样式，包括增大发光渐变范围以及微调内边距。

文档：
- 从所有受支持的语言环境中移除与镜像检测和速度测试相关的翻译键。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the release download flow to remove mirror detection and progress tracking and redirect users directly to the GitHub download URL.

Enhancements:
- Streamline the download state machine to only handle idle and downloading states and update the UI copy to reflect direct GitHub downloads.
- Move platform detection definitions to a shared utils/detect module and drop per-platform downloaded message metadata.
- Adjust download button styling, including increased glow gradient scale and padding tweaks.

Documentation:
- Remove mirror detection and speed test related translation keys from all supported locales.

</details>